### PR TITLE
feat: 2D Delta Encoding / DeltaDiffPackSink

### DIFF
--- a/examples/2d_delta_bench.rs
+++ b/examples/2d_delta_bench.rs
@@ -1,0 +1,61 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::time::Instant;
+use compressed_vec::nibblepacking;
+
+///
+/// 2d_delta_bench <<CSV histogram file>>
+/// An example benchmark that reads histogram data from a file and repeatedly decodes delta-encoded
+/// histograms using DeltaDiffPackSink (ie re-encoding into 2D diff encoded histograms that aren't
+/// increasing any more)
+/// Each line of the file is CSV, no headers, and is expected to be Prom style (ie increasing bucket to bucket
+/// and increasing over time).
+///
+/// NOTE: be sure to compile in release mode for benchmarking, ie cargo build --release --example 2d_delta_bench
+fn main() {
+    const NUM_BUCKETS: usize = 64;
+    const NUM_LOOPS: usize = 1000;
+
+    let filename = std::env::args().nth(1).expect("No filename given");
+    let file = File::open(filename).unwrap();
+    let mut srcbuf = Vec::<u8>::with_capacity(65536);
+    let mut num_lines = 0;
+
+    for line in BufReader::new(&file).lines() {
+        // Split and trim lines, parsing into u64.  Delta encode
+        let mut last = 0u64;
+        let line = line.expect("Could not parse line");
+        let num_iter = line.split(',')
+                           .map(|s| s.trim().parse::<u64>().unwrap())
+                           .map(|n| {
+                               let delta = n.saturating_sub(last);
+                               last = n;
+                               delta
+                           });
+        nibblepacking::pack_u64(num_iter, &mut srcbuf);
+        num_lines += 1;
+    }
+
+    println!("Finished reading and compressing {} histograms, now running {} iterations of 2D Delta...",
+             num_lines, NUM_LOOPS);
+
+    let out_buf = Vec::with_capacity(4096);
+    let mut sink = nibblepacking::DeltaDiffPackSink::new(NUM_BUCKETS, out_buf);
+    let start = Instant::now();
+
+    for _ in 0..NUM_LOOPS {
+        // Reset out_buf and sink last_deltas state
+        sink.reset();
+        let mut slice = &srcbuf[..];
+
+        for _ in 0..num_lines {
+            let res = nibblepacking::unpack(slice, &mut sink, NUM_BUCKETS);
+            sink.finish();
+            slice = res.unwrap();
+        }
+    }
+
+    let elapsed_millis = start.elapsed().as_millis();
+    let rate = (num_lines * NUM_LOOPS * 1000) as u128 / elapsed_millis;
+    println!("{} encoded in {} ms = {} histograms/sec", num_lines * NUM_LOOPS, elapsed_millis, rate);
+}

--- a/src/byteutils.rs
+++ b/src/byteutils.rs
@@ -50,18 +50,3 @@ pub unsafe fn unchecked_write_u64_u64_le(out_buffer: &mut Vec<u64>, value: u64) 
     std::ptr::write(ptr, value.to_le());
     out_buffer.set_len(cur_len + 1);
 }
-
-/// Writes eight u64 values in rapid succession to the Vec, directly, using unsafe,
-/// for performance reasons / to avoid checks on every single write.
-/// It is safe because of checks done on the overall write.
-pub fn write8_u64_le(out_buffer: &mut Vec<u64>, value: u64) {
-    out_buffer.reserve(8);
-    unsafe {
-        let cur_len = out_buffer.len();
-        let ptr = out_buffer.as_mut_ptr().offset(cur_len as isize);
-        for i in 0..8 {
-            std::ptr::write(ptr.add(i), value.to_le());
-        }
-        out_buffer.set_len(cur_len + 8);
-    }
-}

--- a/src/byteutils.rs
+++ b/src/byteutils.rs
@@ -1,7 +1,11 @@
-extern crate byteorder;
-
-use self::byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::io::Cursor;
+
+#[derive(Debug, PartialEq)]
+pub enum NibblePackError {
+    InputTooShort,
+}
+
 
 /// Fast write of u64.  numbytes least significant bytes are written.  May overwrite, but it's fine
 /// because this is a Vec which can be extended.  Vec.len() is always advanced numbytes.
@@ -19,16 +23,20 @@ pub fn direct_write_uint_le(out_buffer: &mut Vec<u8>, value: u64, numbytes: usiz
 /// Reads u64 value, even if there are less than 8 bytes left.  Reads are little endian.
 /// Cursor state is modified.  Will never read beyond end of inbuf.
 #[inline(always)]
-pub fn direct_read_uint_le(cursor: &mut Cursor<&[u8]>, inbuf: &[u8]) -> u64 {
-    let pos = cursor.position() as usize;
-    if (pos + 8) <= inbuf.len() {
-        // TODO: use Result's unwrap_or_else to handle if input is short
-        cursor.read_u64::<LittleEndian>().unwrap()
-    } else {
-        // Less than 8 bytes left.  Use Byteorder implementation which can read limited # of bytes.
-        // This ensures we don't read from a space we are not allowed to.
-        cursor.read_uint::<LittleEndian>(inbuf.len() - pos).unwrap()
-    }
+pub fn direct_read_uint_le(cursor: &mut Cursor<&[u8]>, inbuf: &[u8]) -> Result<u64, NibblePackError> {
+    let pos = cursor.position();
+    cursor.read_u64::<LittleEndian>()
+        // Not enough space.  Use read_uint to never read beyond remaining bytes - be safe
+        .or_else(|_e| {
+            let remaining = (inbuf.len() as isize) - (pos as isize);
+            if remaining > 0 {
+                cursor.set_position(pos);
+                cursor.read_uint::<LittleEndian>(remaining as usize)
+                    .map_err(|_e| NibblePackError::InputTooShort)
+            } else {
+                Err(NibblePackError::InputTooShort)
+            }
+        })
 }
 
 /// Writes a u64 directly to a vec<u64>, without checking for or reserving more space.

--- a/src/byteutils.rs
+++ b/src/byteutils.rs
@@ -1,46 +1,33 @@
 extern crate byteorder;
 
-use self::byteorder::{LittleEndian, ReadBytesExt};
+use self::byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use std::io::Cursor;
 
-// TODO: change these to be Vec implementations?  or Writer?
-
-/// Function to write a u64 to memory quickly using unaligned writes.  The Vec state/len is updated & capacity checked.
-/// Equivalent of sun.misc.Unsafe, but it checks Vec has enough space so in theory it should be safe
-/// It is 2-3x faster than the equivalent code from byteorder, which uses memcpy instead.
-/// TODO: write a method which works on multiple 64-bit inputs or partial inputs so the pointer state, reservation etc
-///       can be amortized and the below can be a cheaper write.
+/// Fast write of u64.  numbytes least significant bytes are written.  May overwrite, but it's fine
+/// because this is a Vec which can be extended.  Vec.len() is always advanced numbytes.
 #[inline]
 pub fn direct_write_uint_le(out_buffer: &mut Vec<u8>, value: u64, numbytes: usize) {
-    out_buffer.reserve(8);
-    unsafe {
-        // We have checked the capacity so this is OK
-        unsafe_write_uint_le(out_buffer, value, numbytes);
+    if numbytes == 8 {
+        out_buffer.write_u64::<LittleEndian>(value).unwrap();
+    } else {
+        let orig_len = out_buffer.len();
+        out_buffer.write_u64::<LittleEndian>(value).unwrap();
+        out_buffer.truncate(orig_len + numbytes);
     }
 }
 
+/// Reads u64 value, even if there are less than 8 bytes left.  Reads are little endian.
+/// Cursor state is modified.  Will never read beyond end of inbuf.
 #[inline(always)]
-unsafe fn unsafe_write_uint_le(out_buffer: &mut Vec<u8>, value: u64, numbytes: usize) {
-    let cur_len = out_buffer.len();
-    let ptr = out_buffer.as_mut_ptr().offset(cur_len as isize) as *mut u64;
-    std::ptr::write_unaligned(ptr, value.to_le());
-    out_buffer.set_len(cur_len + numbytes);
-}
-
-/// Safe but fast read from inbuf.  If it can read 64 bits then uses fast unaligned read, otherwise
-/// uses byteorder crate.  Also does Endianness conversion.
-#[inline(always)]
-pub fn direct_read_uint_le(inbuf: &[u8], index: u32) -> u64 {
-    if ((index as usize) + 8) <= inbuf.len() {
-        unsafe {
-            let ptr = inbuf.as_ptr().offset(index as isize) as *const u64;
-            u64::from_le(std::ptr::read_unaligned(ptr))
-        }
+pub fn direct_read_uint_le(cursor: &mut Cursor<&[u8]>, inbuf: &[u8]) -> u64 {
+    let pos = cursor.position() as usize;
+    if (pos + 8) <= inbuf.len() {
+        // TODO: use Result's unwrap_or_else to handle if input is short
+        cursor.read_u64::<LittleEndian>().unwrap()
     } else {
         // Less than 8 bytes left.  Use Byteorder implementation which can read limited # of bytes.
         // This ensures we don't read from a space we are not allowed to.
-        let mut cursor = std::io::Cursor::new(inbuf);
-        cursor.set_position(index as u64);
-        cursor.read_uint::<LittleEndian>(inbuf.len() - index as usize).unwrap()
+        cursor.read_uint::<LittleEndian>(inbuf.len() - pos).unwrap()
     }
 }
 

--- a/src/byteutils.rs
+++ b/src/byteutils.rs
@@ -9,7 +9,6 @@ use self::byteorder::{LittleEndian, ReadBytesExt};
 /// It is 2-3x faster than the equivalent code from byteorder, which uses memcpy instead.
 /// TODO: write a method which works on multiple 64-bit inputs or partial inputs so the pointer state, reservation etc
 ///       can be amortized and the below can be a cheaper write.
-#[inline]
 pub fn direct_write_uint_le(out_buffer: &mut Vec<u8>, value: u64, numbytes: usize) {
     out_buffer.reserve(8);
     unsafe {
@@ -59,7 +58,6 @@ pub unsafe fn unchecked_write_u64_u64_le(out_buffer: &mut Vec<u64>, value: u64) 
 /// Writes eight u64 values in rapid succession to the Vec, directly, using unsafe,
 /// for performance reasons / to avoid checks on every single write.
 /// It is safe because of checks done on the overall write.
-#[inline]
 pub fn write8_u64_le(out_buffer: &mut Vec<u64>, value: u64) {
     out_buffer.reserve(8);
     unsafe {

--- a/src/nibblepacking.rs
+++ b/src/nibblepacking.rs
@@ -100,7 +100,6 @@ pub fn pack_u64<I: Iterator<Item = u64>>(stream: I, out_buffer: &mut Vec<u8>) {
 /// * `inputs` - ref to 8 u64 values to pack, could be the output of a predictor
 /// * `out_buffer` - a vec to write the encoded output to.  Bytes are added at the end - vec is not cleared.
 ///
-#[inline]
 pub fn nibble_pack8(inputs: &[u64; 8], out_buffer: &mut Vec<u8>) {
     // Compute the nonzero bitmask.  TODO: use SIMD here
     let mut nonzero_mask = 0u8;
@@ -145,7 +144,6 @@ pub fn nibble_pack8(inputs: &[u64; 8], out_buffer: &mut Vec<u8>) {
 /// # Arguments
 /// * `trailing_zero_nibbles` - the min # of trailing zero nibbles across all inputs
 /// * `num_nibbles` - the max # of nibbles having nonzero bits in all inputs
-#[inline]
 fn pack_to_even_nibbles(
     inputs: &[u64; 8],
     out_buffer: &mut Vec<u8>,
@@ -168,7 +166,6 @@ fn pack_to_even_nibbles(
 /// This code is inspired by bitpacking crate: https://github.com/tantivy-search/bitpacking/
 /// but modified for the NibblePacking algorithm.  No macros, so slightly less efficient.
 /// TODO: consider using macros like in bitpacking to achieve even more speed :D
-#[inline]
 fn pack_universal(
     inputs: &[u64; 8],
     out_buffer: &mut Vec<u8>,

--- a/src/nibblepacking.rs
+++ b/src/nibblepacking.rs
@@ -2,11 +2,6 @@
 
 use crate::byteutils::*;
 
-#[derive(Debug, PartialEq)]
-pub enum NibblePackError {
-    InputTooShort,
-}
-
 /// Packs a slice of u64 numbers that are increasing, using delta encoding.  That is, the delta between successive
 /// elements is encoded, rather than the absolute numbers.  The first number is encoded as is.
 ///
@@ -482,16 +477,12 @@ pub fn unpack<'a, Output: Sink>(
 pub fn unpack_f64_xor<'a>(encoded: &'a [u8],
                           sink: &mut DoubleXorSink,
                           num_values: usize) -> Result<&'a [u8], NibblePackError> {
-    if (encoded.len() < 8) {
-        Err(NibblePackError::InputTooShort)
-    } else {
-        assert!(num_values >= 1);
-        let mut cursor = std::io::Cursor::new(encoded);
-        let init_value = direct_read_uint_le(&mut cursor, encoded);
-        sink.reset(init_value);
+    assert!(num_values >= 1);
+    let mut cursor = std::io::Cursor::new(encoded);
+    let init_value = direct_read_uint_le(&mut cursor, encoded)?;
+    sink.reset(init_value);
 
-        unpack(&encoded[8..], sink, num_values - 1)
-    }
+    unpack(&encoded[8..], sink, num_values - 1)
 }
 
 /// Unpacks 8 u64's packed using nibble_pack8 by calling the output.process() method 8 times, once for each encoded
@@ -524,7 +515,7 @@ fn nibble_unpack8<'a, Output: Sink>(
         cursor.set_position(2);
 
         // Read in first word
-        let mut in_word = direct_read_uint_le(&mut cursor, inbuf);
+        let mut in_word = direct_read_uint_le(&mut cursor, inbuf)?;
 
         output.reserve(8);
 
@@ -539,15 +530,11 @@ fn nibble_unpack8<'a, Output: Sink>(
                 // If remaining bits are in next word, read next word -- if there's space
                 // We don't want to read the next word though if we're already at the end
                 if remaining <= num_bits && cursor.position() < (total_bytes as u64) {
-                    if ((cursor.position() as usize) < inbuf.len()) {
-                        // Read in MSB bits from next wordå
-                        in_word = direct_read_uint_le(&mut cursor, inbuf);
-                        if remaining < num_bits {
-                            let shifted = in_word << remaining;
-                            out_word |= shifted & mask;
-                        }
-                    } else {
-                        return Err(NibblePackError::InputTooShort);
+                    // Read in MSB bits from next word
+                    in_word = direct_read_uint_le(&mut cursor, inbuf)?;
+                    if remaining < num_bits {
+                        let shifted = in_word << remaining;
+                        out_word |= shifted & mask;
                     }
                 }
 

--- a/src/nibblepacking.rs
+++ b/src/nibblepacking.rs
@@ -363,7 +363,7 @@ impl Sink for DoubleXorSink {
 /// For more details, see the "2D Delta" section in [compression.md](doc/compression.md)
 #[derive(Default)]
 #[derive(Debug)]
-struct DeltaDiffPackSink {
+pub struct DeltaDiffPackSink {
     value_dropped: bool,
     i: usize,
     last_hist_deltas: Vec<u64>,
@@ -381,12 +381,13 @@ impl DeltaDiffPackSink {
 
     // Resets everythin, even the out_vec.  Probably should be used only for testing
     #[inline]
-    fn reset(&mut self) {
+    pub fn reset(&mut self) {
         self.i = 0;
         self.value_dropped = false;
         for elem in self.last_hist_deltas.iter_mut() {
             *elem = 0;
         }
+        self.out_vec.truncate(0);
     }
 
     /// Call this to finish packing the remainder of the deltas and reset for next go
@@ -430,14 +431,15 @@ impl Sink for DeltaDiffPackSink {
     #[inline]
     fn process8(&mut self, data: u64) {
         // Shortcut only if data==0: then just pack zeroes
-        if data == 0 {
-            assert!((self.i % 8) == 0);
-            nibble_pack8(&[0; 8], &mut self.out_vec);
-        } else {
+        // Disable for now as we are not completely sure if this is legit
+        // if data == 0 {
+        //     assert!((self.i % 8) == 0);
+        //     nibble_pack8(&[0; 8], &mut self.out_vec);
+        // } else {
             for _ in 0..8 {
                 self.process(data);
             }
-        }
+        // }
     }
 }
 


### PR DESCRIPTION
A sink that re-compresses delta-compressed histograms, making them smaller by encoding the difference between the new histogram and the last histogram.  Works well for increasing histograms a la Prometheus.

Includes an example app that can benchmark the recompression/encoding as an independent app.